### PR TITLE
Relaxed version bounds and type variable fix

### DIFF
--- a/src/ComonadSheet.cabal
+++ b/src/ComonadSheet.cabal
@@ -43,7 +43,7 @@ library
       TupleSections
 
   build-depends:
-      base >=4.7 && < 4.8,
+      base >=4.7,
       comonad >=4.0,
       distributive >=0.1,
       transformers >=0.3,

--- a/src/Control/Comonad/Sheet/Manipulate.hs
+++ b/src/Control/Comonad/Sheet/Manipulate.hs
@@ -225,10 +225,10 @@ class DimensionalAs x y where
 
 -- | In the case of a @Nested@ structure, @asDimensionalAs@ defaults to @asNestedAs@.
 instance (NestedAs x (Nested ts y), AsDimensionalAs x (Nested ts y) ~ AsNestedAs x (Nested ts y)) => DimensionalAs x (Nested ts y) where
-   type x `AsDimensionalAs` (Nested ts a) = x `AsNestedAs` (Nested ts a)
+   type x `AsDimensionalAs` (Nested ts y) = x `AsNestedAs` (Nested ts y)
    asDimensionalAs = asNestedAs
 
 -- | @DimensionalAs@ also knows the dimensionality of an 'Indexed' sheet as well as regular @Nested@ structures.
 instance (NestedAs x (Nested ts y)) => DimensionalAs x (Indexed ts y) where
-   type x `AsDimensionalAs` (Indexed ts a) = x `AsNestedAs` (Nested ts a)
+   type x `AsDimensionalAs` (Indexed ts y) = x `AsNestedAs` (Nested ts y)
    x `asDimensionalAs` (Indexed i t)       = x `asNestedAs` t


### PR DESCRIPTION
This, including the changes to dependencies in #5 make the library build on GHC 8.10.4.